### PR TITLE
BrightSign Config Generator Tool Improvements

### DIFF
--- a/BrightSign/index.html
+++ b/BrightSign/index.html
@@ -89,7 +89,7 @@
             <option value="XC2055" selected>XC2055</option>
             <option value="XC4055">XC4055</option>
             <option value="XT2145">XT2145</option>
-            <option value="LG445">LG445</option>
+            <option value="LGUV5N">LGUV5N</option>
             <option value="other">Other</option>
           </select>
         </p>

--- a/BrightSign/index.html
+++ b/BrightSign/index.html
@@ -61,6 +61,10 @@
           /><br />
         </p>
         <p>
+          <label>Gapless Widget Transitions:</label>
+          <input type="checkbox" id="gaplessWidgetTransitionsEnabled" /><br />
+        </p>
+        <p>
           <label>Always Embed Webpages:</label>
           <input type="checkbox" id="alwaysEmbedWebpagesEnabled" /><br />
         </p>

--- a/BrightSign/index.html
+++ b/BrightSign/index.html
@@ -85,6 +85,7 @@
             <option value="XC2055" selected>XC2055</option>
             <option value="XC4055">XC4055</option>
             <option value="XT2145">XT2145</option>
+            <option value="LG445">LG445</option>
             <option value="other">Other</option>
           </select>
         </p>

--- a/BrightSign/index.html
+++ b/BrightSign/index.html
@@ -73,7 +73,7 @@
           "
         />
         <p>
-          <label>Is Series 5 Device (XC5, XT5, XD5, HD5, LS5)?</label>
+          <label>Is Series 5 or 6 Device (HD6, XD6, XC5, XT5, XD5, HD5, LS5)?</label>
           <select id="multipleOutputEnabled">
             <option value="No" selected>No</option>
             <option value="Yes">Yes</option>

--- a/BrightSign/js/main.js
+++ b/BrightSign/js/main.js
@@ -20,12 +20,18 @@ $("#multipleOutputEnabled").change(function () {
     $("#globalAudioEnabledControl").attr("hidden", false);
     $("#screen1AudioEnabledControl").attr("hidden", true);
     loadDefaultConfigurationOptions();
+    resetResolutionOptions();
   } else {
     $("#audioChannelControl").attr("hidden", false);
     $("#audioEnabledControl").attr("hidden", true);
     $("#globalAudioEnabledControl").attr("hidden", true);
     $("#screen1AudioEnabledControl").attr("hidden", false);
     loadMultiScreenConfigurationOptions();
+    
+    // Check if LG445 is selected and restrict resolution options if needed
+    if ($("#multipleOutputDevice").val() == "LG445") {
+      restrictResolutionForLG445();
+    }
   }
 });
 
@@ -37,6 +43,13 @@ $("#kioskModeEnabled").change(function () {
 
 $("#multipleOutputDevice").change(function () {
   loadMultiScreenConfigurationOptions();
+  
+  // Handle LG445 device special case - restrict resolution options
+  if ($("#multipleOutputDevice").val() == "LG445") {
+    restrictResolutionForLG445();
+  } else {
+    resetResolutionOptions();
+  }
 });
 
 $("#mode").change(function () {
@@ -497,16 +510,59 @@ function loadMultiScreenConfigurationOptions() {
   $("#screen1 .title").show();
   $("#screen1 .Screen1Coords").show();
   $("#outputDevice").show();
-  $("#screen2").show();
+  
   if ($("#multipleOutputDevice").val() == "XC4055") {
+    $("#screen2").show();
     $("#screen3").show();
     $("#screen4").show();
+    self.screens = ["HDMI-1", "HDMI-2", "HDMI-3", "HDMI-4"];
   } else if ($("#multipleOutputDevice").val() == "XC2055" || $("#multipleOutputDevice").val() == "XT2145") {
+    $("#screen2").show();
     $("#screen3").hide();
     $("#screen4").hide();
-  } else {
+    self.screens = ["HDMI-1", "HDMI-2"];
+  } else if ($("#multipleOutputDevice").val() == "LG445") {
     $("#screen2").hide();
     $("#screen3").hide();
     $("#screen4").hide();
+    self.screens = ["HDMI-1"];
+  }
+}
+
+function restrictResolutionForLG445() {
+  for (let i = 1; i <= 4; i++) {
+    const videomodeSelect = $(`#videomodeScreen${i}`);
+    
+    // Store the video mode options if not already stored
+    if (!videomodeSelect.data('original-options')) {
+      videomodeSelect.data('original-options', videomodeSelect.html());
+    }
+    
+    // Replace with only the 3840x2160x60p option
+    videomodeSelect.html('<option value="3840x2160x60p">3840x2160x60p</option>');
+    
+    if ($(`#enabledScreen${i}`).is(":checked")) {
+      $(`#colorspaceScreen${i}`).prop('disabled', false);
+      $(`#bitdepthScreen${i}`).prop('disabled', false);
+    }
+  }
+}
+
+function resetResolutionOptions() {
+  // Restore original resolution options for screens 1-4
+  for (let i = 1; i <= 4; i++) {
+    const videomodeSelect = $(`#videomodeScreen${i}`);
+    
+    // Restore original options if they were stored
+    if (videomodeSelect.data('original-options')) {
+      videomodeSelect.html(videomodeSelect.data('original-options'));
+    }
+    
+    // Reset disabled state based on selected item
+    const selectedItem = videomodeSelect[0].selectedIndex;
+    if (selectedItem == 0) {
+      $(`#colorspaceScreen${i}`).prop('disabled', true);
+      $(`#bitdepthScreen${i}`).prop('disabled', true);
+    }
   }
 }

--- a/BrightSign/js/main.js
+++ b/BrightSign/js/main.js
@@ -28,9 +28,9 @@ $("#multipleOutputEnabled").change(function () {
     $("#screen1AudioEnabledControl").attr("hidden", false);
     loadMultiScreenConfigurationOptions();
     
-    // Check if LG445 is selected and restrict resolution options if needed
-    if ($("#multipleOutputDevice").val() == "LG445") {
-      restrictResolutionForLG445();
+    // Check if LGUV5N is selected and restrict resolution options if needed
+    if ($("#multipleOutputDevice").val() == "LGUV5N") {
+      restrictResolutionForLGUV5N();
     }
   }
 });
@@ -44,9 +44,9 @@ $("#kioskModeEnabled").change(function () {
 $("#multipleOutputDevice").change(function () {
   loadMultiScreenConfigurationOptions();
   
-  // Handle LG445 device special case - restrict resolution options
-  if ($("#multipleOutputDevice").val() == "LG445") {
-    restrictResolutionForLG445();
+  // Handle LGUV5N device special case - restrict resolution options
+  if ($("#multipleOutputDevice").val() == "LGUV5N") {
+    restrictResolutionForLGUV5N();
   } else {
     resetResolutionOptions();
   }
@@ -524,7 +524,7 @@ function loadMultiScreenConfigurationOptions() {
     $("#screen3").hide();
     $("#screen4").hide();
     self.screens = ["HDMI-1", "HDMI-2"];
-  } else if ($("#multipleOutputDevice").val() == "LG445") {
+  } else if ($("#multipleOutputDevice").val() == "LGUV5N") {
     $("#screen2").hide();
     $("#screen3").hide();
     $("#screen4").hide();
@@ -532,7 +532,7 @@ function loadMultiScreenConfigurationOptions() {
   }
 }
 
-function restrictResolutionForLG445() {
+function restrictResolutionForLGUV5N() {
   for (let i = 1; i <= 4; i++) {
     const videomodeSelect = $(`#videomodeScreen${i}`);
     

--- a/BrightSign/js/main.js
+++ b/BrightSign/js/main.js
@@ -21,6 +21,7 @@ $("#multipleOutputEnabled").change(function () {
     $("#screen1AudioEnabledControl").attr("hidden", true);
     loadDefaultConfigurationOptions();
     resetResolutionOptions();
+    resetOutputOptions();
   } else {
     $("#audioChannelControl").attr("hidden", false);
     $("#audioEnabledControl").attr("hidden", true);
@@ -30,7 +31,8 @@ $("#multipleOutputEnabled").change(function () {
     
     // Check if LGUV5N is selected and restrict resolution options if needed
     if ($("#multipleOutputDevice").val() == "LGUV5N") {
-      restrictResolutionForLGUV5N();
+      restrictResolutionOptions();
+      restrictOutputOptions();
     }
   }
 });
@@ -46,9 +48,11 @@ $("#multipleOutputDevice").change(function () {
   
   // Handle LGUV5N device special case - restrict resolution options
   if ($("#multipleOutputDevice").val() == "LGUV5N") {
-    restrictResolutionForLGUV5N();
+    restrictResolutionOptions();
+    restrictOutputOptions();
   } else {
     resetResolutionOptions();
+    resetOutputOptions();
   }
 });
 
@@ -532,7 +536,7 @@ function loadMultiScreenConfigurationOptions() {
   }
 }
 
-function restrictResolutionForLGUV5N() {
+function restrictResolutionOptions() {
   for (let i = 1; i <= 4; i++) {
     const videomodeSelect = $(`#videomodeScreen${i}`);
     
@@ -549,6 +553,11 @@ function restrictResolutionForLGUV5N() {
       $(`#bitdepthScreen${i}`).prop('disabled', false);
     }
   }
+}
+
+function restrictOutputOptions() {
+    // Disable enabledScreen1 for LGUV5N
+    $("#enabledScreen1").prop("disabled", true).prop("checked", true);
 }
 
 function resetResolutionOptions() {
@@ -568,4 +577,10 @@ function resetResolutionOptions() {
       $(`#bitdepthScreen${i}`).prop('disabled', true);
     }
   }
+}
+
+function resetOutputOptions() {
+  // Restore output options for screen 1
+    $("#enabledScreen1").prop("disabled", false);
+    $("#enabledScreen1").prop("checked", true);
 }

--- a/BrightSign/js/main.js
+++ b/BrightSign/js/main.js
@@ -439,6 +439,9 @@ $("#generate").click(function () {
     $("#inactivityTimeout").val()
   );
 
+  // Gapless Widget Transitions
+  settings.gaplessWidgetTransitions = $("#gaplessWidgetTransitionsEnabled").is(":checked");
+
   // Always Embed Webpages
   settings.alwaysEmbedWebpages = new Object();
   settings.alwaysEmbedWebpages.enabled = $("#alwaysEmbedWebpagesEnabled").is(":checked");

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       http_parser.rb (~> 0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
+    eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.9.1)
     faraday (2.8.1)
@@ -31,6 +32,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    ffi (1.16.3)
     ffi (1.16.3-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -214,12 +216,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.5)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.21.2)
-    nokogiri (1.15.5-x64-mingw32)
+    nokogiri (1.16.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     nuggets (1.6.1)
     octokit (4.25.1)
@@ -258,6 +264,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
+    unf_ext (0.0.9.1)
     unf_ext (0.0.9.1-x64-mingw32)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
@@ -265,6 +272,7 @@ GEM
 
 PLATFORMS
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   github-pages


### PR DESCRIPTION
**Changes**

- Updated UI labelling to make it clearer regarding support for Series 6 devices. No specific options are required for HD6 and XD6 they should just come under S5 -> Other.
- Added support for LGUV5N
- Added support for gapless widget transitions option
- Made Series 5/6 and Other the default option when loading the tool